### PR TITLE
Move DOMURL into browserImageSize function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,12 @@
-/* istanbul ignore next */
-var DOMURL = require('object-url')
-
 /**
  * Get an image's width and height
  * @param {(File|blob|string)} File, blob, or URL string
  * @returns {Promise} resolved with object containing image width and height
  */
 module.exports = function browserImageSize (image) {
+  /* istanbul ignore next */
+  var DOMURL = require('object-url')
+
   return new Promise(function (resolve, reject) {
     var url = typeof image === 'string' ? image : DOMURL.create(image)
     if (!url) throw new Error('Must use a valid image')


### PR DESCRIPTION
Allows isomorphic code to require browser-image-size
Calling browserImageSize will still throw an error
